### PR TITLE
Optee-tests

### DIFF
--- a/docs/report/M1.md
+++ b/docs/report/M1.md
@@ -44,16 +44,9 @@ The repositories referenced in this milestone have all been published under eith
 | [Zondax/meta-zondax-imx8](https://github.com/Zondax/meta-zondax-imx8)| MIT | [:page_facing_up: License](https://github.com/Zondax/meta-zondax-imx8/blob/honister/LICENSE) | 
 | [Zondax/meta-zondax-stm32mp](https://github.com/Zondax/meta-zondax-stm32mp)| MIT | [:page_facing_up: License](https://github.com/Zondax/meta-zondax-stm32mp/blob/honister/LICENSE) | 
 
-## Documentation
 
-:::warning
-Add short statement to provide evidence (e.g. Link to testing guide)
-:::
-
-## Testing Guide
-:::warning
-ADD The testing guide for this milestone can be found [here](../testing/xtests.md)
-:::
+In the sections below we listed each part of this Milestone and the
+links to their respective test.
 
 ## Item 1
 
@@ -78,9 +71,12 @@ The criterias we used for the selection is described in [this](../technical/10.H
 
 As part of the implementation we used *Yocto* to develop a custom linux distribution for
 each board containing essential dependencies that our trusted application
-needs. This also reduces the number of possible vector attacks,as the number of tools and services, our distribution contains are minimal. 
-Refer to this [section](../technical/30.BSP/30.intro.mdx) to further information about setting-up the basic framework to build 
+needs. This also reduces the number of possible vector attacks, as the number of tools and services, our distribution contains are minimal. 
+Refer to this [section](../technical/30.BSP/30.intro.mdx) for further information about setting-up the basic framework to build 
 our custom linux-distribution and how to run it on each supported device.
+
+In [this](../testing/xtests.md) section you can find further instructions on how to test the basic optee
+framework that comes as part of our custom linux distribution.
 
 :::info
 [Yocto](https://www.yoctoproject.org/)  is a framework to create custom linux distributions.

--- a/docs/technical/20.HardwareSetup/20.intro.mdx
+++ b/docs/technical/20.HardwareSetup/20.intro.mdx
@@ -3,8 +3,7 @@ title: Hardware Setup
 sidebar_position: 20
 ---
 
-Read the instruction provided for your board in this section that tell
-you how to setup your board and how to log to your device using Minicom.
+In this section you can read the instruction that tells you how to setup your board and how to log to your device using Minicom.
 Once you know how to use Minicom, you can configure a __SSH__ connection
 to your board as indicated in the note bellow.
 :::note

--- a/docs/testing/xtests.md
+++ b/docs/testing/xtests.md
@@ -8,7 +8,7 @@ The first step after [flashing](../technical/30.BSP/99.Flashing.mdx) the SD Card
 These tests are important because they ensure that the Tee kernel drivers and supplicant that are
 running on the device work and behave as they are supposed to do and
 they show what parts of optee fail. 
-Optee has many features, some of then are not really necessary, like secure tcp
+Optee has many features, some of them are not really necessary, like secure tcp
 sockets, peripheral communication like SPI or serial ports. As those
 features are not necessary for our application, even though some optee
 tests fail they might not be critical.
@@ -24,7 +24,7 @@ Refer to the [official](https://optee.readthedocs.io/en/latest/building/gits/opt
 :::
 
 
-for the __STM32MP157F-DK2__ board the test summary would look like:
+for the __STM32MP157F-DK2__ board the test summary would look like this:
 ```bash
 regression_6017 OK
 regression_6018.1 FAILED first error at /usr/src/debug/optee-test/3.14.0+gitAUTOINC+f2eb88affb-r0/git/host/xtest/regression_6000.c:1707
@@ -43,7 +43,7 @@ regression_8103 OK
 0 test cases were skipped
 TEE test application done!
 ```
-You could see in some part of the output an error like:
+You could see in some part of the output an error like this:
  
 ```bash
 /usr/src/debug/optee-test/3.14.0+gitAUTOINC+f2eb88affb-r0/git/host/xtest/regression_6000.c:1707: fs_write(&sess, obj, block, block_size) has an unexpected value: 0xffff3024 = TEE_ERROR_TARGET_DEAD, expected 0x0 = TEEC_SUCCESS
@@ -57,7 +57,7 @@ o regression_6018.2 Storage id: 80000000
 We are still investigating this error that is part of an API of Optee
 that our application does not us. 
 
-Regarding to the __8MMINILPD4-EVKB__ board the test summary would look like:
+Regarding to the __8MMINILPD4-EVKB__ board the test summary would look like this:
 ```text
 24688 subtests of which 12 FAILED92 test cases of which 5 FAILED0 test
 cases were skipped
@@ -75,8 +75,8 @@ o regression_4005.2 AE case 1 algo 0x40000710 line 2407
   regression_4005 FAILED
 ```
 They called the AES encryption and decryption API(some functions of this API) in optee which our application does not use.
-We only use the allocation API from and the sandboxing feature that offers us a way to 
-run secure application in an isolating manner. Advances features like secure file system, secure peripheral communication and
+We only use the allocation API and the sandboxing feature that offers us a way to 
+run secure application in an isolating manner. Advances features like secure file systems, secure peripheral communications and
 symmetric/asymmetric encryption are out of the scope of our application.
 
 :::note


### PR DESCRIPTION
Add documentation on
- how to run optee tests along with comments on why some failing tests are not important for our application
- How to use SSH as an alternative to not use minicom more than once
- Reference the xtests documentation in M1 report